### PR TITLE
Switched from `std::ffi::CStr` to `core::ffi::CStr` (Rust 1.64.0+)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ rust-version = "1.64.0"
 [dependencies]
 libc = { version = "^0.2.0", default-features = false, optional = true }
 
+[dev-dependencies]
+libc = { version = "^0.2.0", default-features = false }
+
 [features]
 # use types currently available only from `libc` and not `core::ffi`
 libc = ["dep:libc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,17 @@ keywords = ["printf", "ffi", "c", "no_std"]
 rust-version = "1.64.0"
 
 [dependencies]
-libc = { version = "^0.2.0", default-features = false }
+libc = { version = "^0.2.0", default-features = false, optional = true }
 
 [features]
-# use the nightly-only #[doc(cfg(...))]:
-doccfg = []
+# use types currently available only from `libc` and not `core::ffi`
+libc = ["dep:libc"]
 # include the "example" module
-example = []
+example = ["dep:libc"]
+# use the nightly-only #[doc(cfg(...))]; intended for use when generating docs
+doccfg = ["dep:libc"]
 
 [package.metadata.docs.rs]
-features = ["example", "doccfg"]
+features = ["libc", "example", "doccfg"]
 default-target = "x86_64-unknown-linux-gnu"
 targets = ["x86_64-apple-darwin", "x86_64-unknown-freebsd", "x86_64-unknown-illumos"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,21 +9,18 @@ documentation = "https://docs.rs/printf-wrap"
 readme = "README.md"
 categories = ["development-tools::ffi", "no-std"]
 keywords = ["printf", "ffi", "c", "no_std"]
-rust-version = "1.61.0"
+rust-version = "1.64.0"
 
 [dependencies]
 libc = { version = "^0.2.0", default-features = false }
 
 [features]
-default = ["std"]
-# use the `std` crate:
-std = []
 # use the nightly-only #[doc(cfg(...))]:
 doccfg = []
 # include the "example" module
 example = []
 
 [package.metadata.docs.rs]
-features = ["std", "example", "doccfg"]
+features = ["example", "doccfg"]
 default-target = "x86_64-unknown-linux-gnu"
 targets = ["x86_64-apple-darwin", "x86_64-unknown-freebsd", "x86_64-unknown-illumos"]

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ values to C-compatible equivalents.
 
 ## Features
 
-**std** &ndash; enables support for the [`CStr`] and [`CString`] types from [`std`].
-Enabled by default; if you want to use this crate in `#[no_std]` environments,
-[`default-features = false`] in the dependency declaration is your friend.
+**`libc`** &ndash; enables support relating to the C types
+`size_t`, `intmax_t`, and `ptrdiff_t`; requires the [`libc`] crate.
 
-**example** &ndash; enables a demonstration of the use of `printf-wrap`
-with some wrappers around functions from the C standard library.
+**`example`** &ndash; enables a demonstration of the use of `printf-wrap`
+with some wrappers around functions from the C standard library; also
+requires the [`libc`] crate.
 
 ## License
 
@@ -55,7 +55,4 @@ This crate is licensed under either of the [MIT license](LICENSE-MIT)
 or the [Apache License version 2.0](LICENSE-Apache-2.0) at your option.
 
 [`printf(3)`]: https://man7.org/linux/man-pages/man3/printf.3.html
-[`std`]: https://doc.rust-lang.org/std/index.html
-[`CStr`]: https://doc.rust-lang.org/std/ffi/type.CStr.html
-[`CString`]: https://doc.rust-lang.org/std/ffi/type.CString.html
-[`default-features = false`]: https://doc.rust-lang.org/cargo/reference/features.html#dependency-features
+[`libc`]: https://crates.io/crates/libc

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,9 +76,8 @@ extern crate libc;
 #[cfg(any(test, doc))]
 extern crate alloc;
 
-use core::ffi::CStr;
+use core::ffi::{c_char, CStr};
 use core::marker::PhantomData;
-use libc::c_char;
 
 use crate::private::PrintfArgumentPrivate;
 use crate::validate::is_fmt_valid_for_args;
@@ -323,7 +322,7 @@ pub struct PrintfFmt<T: PrintfArgs> {
     _y: PhantomData<T>,
 }
 
-/// Utility conversion from [`u8`] to [`libc::c_char`].
+/// Utility conversion from [`u8`] to [`c_char`].
 const fn c(x: u8) -> c_char {
     x as c_char
 }
@@ -403,6 +402,12 @@ impl<T: PrintfArgs> Clone for PrintfFmt<T> {
 }
 
 impl<T: PrintfArgs> Copy for PrintfFmt<T> {}
+
+impl<T: PrintfArgs> AsRef<CStr> for PrintfFmt<T> {
+    fn as_ref(&self) -> &CStr {
+        unsafe { CStr::from_ptr(self.fmt) }
+    }
+}
 
 /// Returns whether `fmt` is (1) a valid C-style string and (2) a format
 /// string compatible with the tuple of arguments `T` when used in a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,7 +412,7 @@ pub const fn is_fmt_valid<T: PrintfArgs>(fmt: &[c_char]) -> bool {
     is_fmt_valid_for_args::<T>(fmt, false)
 }
 
-#[cfg(any(feature = "example", all(doc, feature = "doccfg")))]
+#[cfg(any(feature = "example", all(doc, feature = "doccfg"), test))]
 #[cfg_attr(feature = "doccfg", doc(cfg(feature = "example")))]
 pub mod example;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,8 @@
 //!   supported.
 //! * `%lc`, `%ls`, `%C`, `%S`, and `%L[fFeEgGaA]` are not supported.
 //! * `%n` is not supported.
+//! * The `j`, `z`, and `t` length modifiers are only supported
+//!   if crate feature **`libc`** is enabled.
 //!
 //! [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/printf.html
 //! [Linux]: https://man7.org/linux/man-pages/man3/printf.3.html
@@ -70,7 +72,9 @@
 #[derive(Clone, Copy, Debug)]
 struct CompatibleSystem {}
 
-// We use `libc` for types, and (in the `example` module) for functions from the C standard library.
+// We optionally use `libc` for types and (in the `example` module)
+// for functions from the C standard library.
+#[cfg(any(feature = "libc", feature = "example", test, all(doc, feature = "doccfg")))]
 extern crate libc;
 
 #[cfg(any(test, doc))]
@@ -192,10 +196,16 @@ pub trait PrintfArgument: PrintfArgumentPrivate + Copy {
     /// Whether the type is consistent with C's `long long int`.
     const IS_LONG_LONG: bool = false;
     /// Whether the type is consistent with C's `size_t`.
+    #[cfg(any(feature = "libc", test, all(doc, feature = "doccfg")))]
+    #[cfg_attr(feature = "doccfg", doc(cfg(feature = "libc")))]
     const IS_SIZE: bool = false;
     /// Whether the type is consistent with C's `intmax_t`.
+    #[cfg(any(feature = "libc", test, all(doc, feature = "doccfg")))]
+    #[cfg_attr(feature = "doccfg", doc(cfg(feature = "libc")))]
     const IS_MAX: bool = false;
     /// Whether the type is consistent with C's `ptrdiff_t`.
+    #[cfg(any(feature = "libc", test, all(doc, feature = "doccfg")))]
+    #[cfg_attr(feature = "doccfg", doc(cfg(feature = "libc")))]
     const IS_PTRDIFF: bool = false;
 
     /// Whether the type is a signed integer type, as opposed to unsigned.

--- a/src/printf_arg_impls.rs
+++ b/src/printf_arg_impls.rs
@@ -6,7 +6,7 @@
 use crate::{is_compat, LargerOf, NullString};
 use crate::{PrintfArgument, PrintfArgumentPrivate};
 
-use core::ffi::c_void;
+use core::ffi::{c_void, CStr};
 use libc::{c_char, c_double, c_int, c_uint};
 
 macro_rules! impl_empty_trait {
@@ -98,37 +98,17 @@ impl PrintfArgument for NullString {
     }
 }
 
-#[cfg(any(feature = "std", all(doc, feature = "doccfg")))]
-#[cfg_attr(feature = "doccfg", doc(cfg(feature = "std")))]
-impl PrintfArgumentPrivate for &std::ffi::CStr {}
+impl<T: AsRef<CStr>> PrintfArgumentPrivate for &T {}
 
-#[cfg(any(feature = "std", all(doc, feature = "doccfg")))]
-#[cfg_attr(feature = "doccfg", doc(cfg(feature = "std")))]
-impl PrintfArgument for &std::ffi::CStr {
+impl<T: AsRef<CStr>> PrintfArgument for &T {
     type CPrintfType = *const c_char;
 
     const IS_C_STRING: bool = true;
 
     #[inline]
     fn as_c_val(self) -> *const c_char {
-        self.as_ptr()
-    }
-}
-
-#[cfg(any(feature = "std", all(doc, feature = "doccfg")))]
-#[cfg_attr(feature = "doccfg", doc(cfg(feature = "std")))]
-impl PrintfArgumentPrivate for &std::ffi::CString {}
-
-#[cfg(any(feature = "std", all(doc, feature = "doccfg")))]
-#[cfg_attr(feature = "doccfg", doc(cfg(feature = "std")))]
-impl PrintfArgument for &std::ffi::CString {
-    type CPrintfType = *const c_char;
-
-    const IS_C_STRING: bool = true;
-
-    #[inline]
-    fn as_c_val(self) -> *const c_char {
-        self.as_ptr()
+        let cs: &CStr = self.as_ref();
+        cs.as_ptr()
     }
 }
 

--- a/src/printf_arg_impls.rs
+++ b/src/printf_arg_impls.rs
@@ -33,8 +33,13 @@ macro_rules! impl_printf_arg_integer {
                 const IS_LONG: bool      = is_compat::<$t, core::ffi::c_long>();
                 const IS_LONG_LONG: bool = is_compat::<$t, core::ffi::c_longlong>();
 
+                #[cfg(any(feature = "libc", test, all(doc, feature = "doccfg")))]
                 const IS_SIZE: bool      = is_compat::<$t, libc::size_t>();
+
+                #[cfg(any(feature = "libc", test, all(doc, feature = "doccfg")))]
                 const IS_MAX: bool       = is_compat::<$t, libc::intmax_t>();
+
+                #[cfg(any(feature = "libc", test, all(doc, feature = "doccfg")))]
                 const IS_PTRDIFF: bool   = is_compat::<$t, libc::ptrdiff_t>();
 
                 type CPrintfType = LargerOf<Self, $int_type>;

--- a/src/printf_arg_impls.rs
+++ b/src/printf_arg_impls.rs
@@ -6,8 +6,7 @@
 use crate::{is_compat, LargerOf, NullString};
 use crate::{PrintfArgument, PrintfArgumentPrivate};
 
-use core::ffi::{c_void, CStr};
-use libc::{c_char, c_double, c_int, c_uint};
+use core::ffi::{c_char, c_double, c_int, c_uint, c_void, CStr};
 
 macro_rules! impl_empty_trait {
     ($trait_name:ident ; $($implementor:ty),*) => {
@@ -28,11 +27,11 @@ macro_rules! impl_printf_arg_integer {
             impl PrintfArgument for $t {
                 const IS_SIGNED: bool = $signed;
 
-                const IS_CHAR: bool      = is_compat::<$t, libc::c_char>();
-                const IS_SHORT: bool     = is_compat::<$t, libc::c_short>();
-                const IS_INT: bool       = is_compat::<$t, libc::c_int>();
-                const IS_LONG: bool      = is_compat::<$t, libc::c_long>();
-                const IS_LONG_LONG: bool = is_compat::<$t, libc::c_longlong>();
+                const IS_CHAR: bool      = is_compat::<$t, core::ffi::c_char>();
+                const IS_SHORT: bool     = is_compat::<$t, core::ffi::c_short>();
+                const IS_INT: bool       = is_compat::<$t, core::ffi::c_int>();
+                const IS_LONG: bool      = is_compat::<$t, core::ffi::c_long>();
+                const IS_LONG_LONG: bool = is_compat::<$t, core::ffi::c_longlong>();
 
                 const IS_SIZE: bool      = is_compat::<$t, libc::size_t>();
                 const IS_MAX: bool       = is_compat::<$t, libc::intmax_t>();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,7 +6,7 @@
 #![cfg(test)]
 
 use crate::NullString;
-use libc::{c_char, c_int, c_long, c_uchar, c_uint, c_ulonglong, c_ushort};
+use core::ffi::{c_char, c_int, c_long, c_uchar, c_uint, c_ulonglong, c_ushort};
 
 macro_rules! generate_construction_panic_case {
     ( $( $fn_name:ident, $str:expr, $args:tt ; )* ) => {
@@ -91,7 +91,7 @@ mod abi_check {
     use crate::example::*;
 
     #[allow(unused_imports)]
-    use libc::{
+    use core::ffi::{
         c_char, c_int, c_long, c_longlong, c_short, c_uchar, c_uint, c_ulong, c_ulonglong, c_ushort,
     };
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -120,8 +120,8 @@ mod abi_check {
                     $( $arg ),*
                 );
                 assert_eq!(
-                    std::str::from_utf8(p),
-                    std::str::from_utf8($expected),
+                    alloc::str::from_utf8(p),
+                    alloc::str::from_utf8($expected),
                     "snprintf was not given the arguments correctly"
                 );
             }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -55,10 +55,13 @@ enum LengthModifier {
     /// `L`
     LongDouble,
     /// `j`
+    #[cfg(any(feature = "libc", test, all(doc, feature = "doccfg")))]
     Max,
     /// `z`
+    #[cfg(any(feature = "libc", test, all(doc, feature = "doccfg")))]
     Size,
     /// `t`
+    #[cfg(any(feature = "libc", test, all(doc, feature = "doccfg")))]
     Ptrdiff,
 }
 
@@ -191,8 +194,11 @@ const fn does_convspec_match_arg<T: PrintfArgsList>(
                 Some(LM::Short) => T::First::IS_SHORT,
                 Some(LM::Long) => T::First::IS_LONG,
                 Some(LM::LongLong) => T::First::IS_LONG_LONG,
+                #[cfg(any(feature = "libc", test, all(doc, feature = "doccfg")))]
                 Some(LM::Max) => T::First::IS_MAX,
+                #[cfg(any(feature = "libc", test, all(doc, feature = "doccfg")))]
                 Some(LM::Size) => T::First::IS_SIZE,
+                #[cfg(any(feature = "libc", test, all(doc, feature = "doccfg")))]
                 Some(LM::Ptrdiff) => T::First::IS_PTRDIFF,
                 Some(LM::LongDouble) => false,
             };
@@ -373,14 +379,17 @@ const fn parse_conversion_specification(
                 Some(Long)
             }
         }
+        #[cfg(any(feature = "libc", test, all(doc, feature = "doccfg")))]
         b'j' => {
             i += 1;
             Some(Max)
         }
+        #[cfg(any(feature = "libc", test, all(doc, feature = "doccfg")))]
         b'z' => {
             i += 1;
             Some(Size)
         }
+        #[cfg(any(feature = "libc", test, all(doc, feature = "doccfg")))]
         b't' => {
             i += 1;
             Some(Ptrdiff)

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -3,7 +3,7 @@
 
 //! Utilities for the validation of the content of candidate format strings.
 
-use libc::c_char;
+use core::ffi::c_char;
 
 use crate::{c, PrintfArgs, PrintfArgsList, PrintfArgument};
 


### PR DESCRIPTION
This pull request resolves issue #1 by (1) using the `CStr` in `core` (as opposed to `std`), now that the recent Rust 1.64.0 release stabilizes its availability and (2) using the C integer types from `core::ffi`, now that most of those have stabilized. In many cases, the `libc` crate is no longer needed as a dependency (though it remains an optional dependency should one need the `%j`, `%z`, or `%t` format specifiers).

This PR also marks `NullString` and `PrintfFmt<T>` as thread-safe.